### PR TITLE
Add futuristic personal CV page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,22 @@
-# React + TypeScript + Vite
+# Personal CV Page
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project contains a simple React site built with **Vite** that showcases Chris Chow's CV. The site is designed with a tech-inspired theme and can be hosted directly on GitHub Pages.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies and start a dev server:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Build
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Create a production build (output in `dist/`):
 
-export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+```bash
+npm run build
 ```
+
+You can then deploy the contents of `dist/` to GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Chris Chow - CV</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,5 @@
 #root {
-	max-width: 1280px;
-	margin: 0 auto;
-	padding: 2rem;
-	text-align: center;
-}
-
-.logo {
-	height: 6em;
-	padding: 1.5em;
-	will-change: filter;
-	transition: filter 300ms;
-}
-.logo:hover {
-	filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-	filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-	from {
-		transform: rotate(0deg);
-	}
-	to {
-		transform: rotate(360deg);
-	}
-}
-
-@media (prefers-reduced-motion: no-preference) {
-	a:nth-of-type(2) .logo {
-		animation: logo-spin infinite 20s linear;
-	}
-}
-
-.card {
-	padding: 2em;
-}
-
-.read-the-docs {
-	color: #888;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,6 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import Resume from './components/Resume'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+export default function App() {
+  return <Resume />
 }
-
-export default App

--- a/src/components/Resume.css
+++ b/src/components/Resume.css
@@ -1,0 +1,41 @@
+.resume-container {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 2rem;
+  color: #e0e0e0;
+  background: radial-gradient(circle at top left, #222, #000);
+  border-radius: 12px;
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+  animation: fadeIn 1s ease-in-out;
+}
+
+.resume-header h1 {
+  margin: 0;
+  font-size: 2.5rem;
+  color: #49eaff;
+  text-shadow: 0 0 10px #49eaff;
+}
+
+.resume-header a {
+  color: #78e0ff;
+}
+
+section {
+  margin-top: 1.5rem;
+  animation: slideUp 0.6s ease both;
+}
+
+h2 {
+  color: #49eaff;
+  text-shadow: 0 0 5px #49eaff;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/src/components/Resume.tsx
+++ b/src/components/Resume.tsx
@@ -1,0 +1,115 @@
+import './Resume.css'
+
+export default function Resume() {
+  return (
+    <div className="resume-container">
+      <header className="resume-header">
+        <h1>Chris Chow</h1>
+        <p>
+          <a href="mailto:chitlchow@gmail.com">chitlchow@gmail.com</a> |
+          <a href="https://www.linkedin.com/in/chitlchow/" target="_blank" rel="noopener noreferrer">
+            LinkedIn
+          </a>
+        </p>
+      </header>
+
+      <section>
+        <h2>Summary</h2>
+        <p>
+          Machine Learning Engineer and Python Developer with a foundation in data science and applied machine learning.
+          Experienced in designing AI models for image generation and predictive analytics. Skilled in working autonomously
+          in startup environments and delivering production-level code. Driven by curiosity and a mission to build impactful,
+          data-driven solutions.
+        </p>
+      </section>
+
+      <section>
+        <h2>Education</h2>
+        <ul>
+          <li>
+            <strong>MSc Data Science</strong> – City, University of London (Oct 2022 – Feb 2024)
+          </li>
+          <li>
+            <strong>BBA in Business Analysis</strong> – City University of Hong Kong (Sep 2016 – Jul 2020)
+            <ul>
+              <li>External Vice President of Executive Committee of Mathematics Society, City University of Hong Kong Students’ Union</li>
+              <li>Floor Representative of Prosperity Hall, City University of Hong Kong</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Work Experience</h2>
+        <ul>
+          <li>
+            <strong>Machine Learning Engineer – Nurturing Reads</strong> (June 2024 - Now)
+            <ul>
+              <li>Founder Engineer for model development in image generation</li>
+            </ul>
+          </li>
+          <li>
+            <strong>STEM Instructor – Cobo Academy, Hong Kong</strong> (Sep 2020 – Sep 2022)
+            <ul>
+              <li>Led business development initiatives teaching and establishing partnerships with more than 20 external parties</li>
+              <li>Instructed technology and coding courses tailored to individuals from diverse technical and non-technical backgrounds</li>
+              <li>Developed a detection model using Python and OpenCV to recognize 14 road signs and weather signs with over 90% accuracy</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Patent Database Assistant – City University of Hong Kong</strong> (Jun 2018 – Aug 2019)
+            <ul>
+              <li>Generated monthly reports from the patent database to facilitate management operations</li>
+              <li>Developed and deployed a data visualization dashboard for executives to streamline patent renewal and sales processes</li>
+              <li>Conducted regular maintenance of the database to uphold data integrity across online and internal platforms</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Projects</h2>
+        <ul>
+          <li>
+            <strong>Recipe Site Traffic Prediction</strong> (May 2024)
+            <ul>
+              <li>Developed and compared models achieving up to 81% precision for identifying recipes with high traffic potential</li>
+              <li>Presented data-driven recommendations that increased engagement potential threefold</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Reinforcement Learning in Snake Game</strong> (May 2023)
+            <ul>
+              <li>Designed and tested a Python-based agent for playing Snake, achieving scores of up to 40 points</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Predictive Analytics on S&amp;P 500 Time Series using Neural Network</strong> (Apr 2023)
+            <ul>
+              <li>Developed and trained RNN and LSTM models on a decade of S&amp;P 500 time series data using Python and PyTorch</li>
+              <li>Optimized the models to achieve an accuracy that accounts for 90% of the variations</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Certifications</h2>
+        <ul>
+          <li>Professional Data Scientist – DataCamp, May 2024</li>
+          <li>SQL Associate – DataCamp, March 2024</li>
+          <li>TensorFlow Developer Certificate – TensorFlow.org, Dec 2023</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Skills Summary</h2>
+        <p>
+          Python, TensorFlow, PyTorch, SQL · Machine Learning, Deep Learning, Predictive Analytics · Image Generation, Time Series Analysis,
+          Data Visualization · Git, Jupyter, VS Code, GitHub · Strong communicator and self-starter in collaborative and independent work environments
+        </p>
+      </section>
+    </div>
+  )
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,21 @@
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+  color: #e0e0e0;
+  background: #050505;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: linear-gradient(135deg, #0d0d0d 0%, #111827 50%, #000 100%);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: #78e0ff;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+h1, h2 {
+  font-weight: 600;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
+  base: '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- switch to a simple CV site
- add Resume React component and styles for futuristic look
- clean up default template
- adjust Vite config for GitHub Pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*
- `npm run build` *(fails: missing packages and types due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd513bb88320a812ccd70cf5f19a